### PR TITLE
Remove tmp file from disk

### DIFF
--- a/src/Converter/GhostscriptConverter.php
+++ b/src/Converter/GhostscriptConverter.php
@@ -69,5 +69,6 @@ class GhostscriptConverter implements ConverterInterface
             throw new \RuntimeException("The generated file '{$tmpFile}' was not found.");
 
         $this->fs->copy($tmpFile, $file, true);
+        $this->fs->remove($tmpFile);        
     }
 }


### PR DESCRIPTION
After copying over the tmp file it should be removed from the disk to clean up disk space.